### PR TITLE
7 cme doesnt handle home command line argument

### DIFF
--- a/src/cme.cpp
+++ b/src/cme.cpp
@@ -33,8 +33,11 @@ You should have received a copy of the GNU General Public License along with thi
 int main(int argc, char const* argv[])
 {
    // This is to check for first appearance of NaN when debugging (comment out, otherwise)
+#ifdef __APPLE__
+#else
    feenableexcept(FE_INVALID | FE_OVERFLOW);
-   
+#endif
+
    // Enable the use of UTF-8 symbols in CoastalME output
    setlocale(LC_ALL, "en_GB.UTF-8");
 

--- a/src/read_input.cpp
+++ b/src/read_input.cpp
@@ -47,8 +47,17 @@ using std::find;
 //===============================================================================================================================
 bool CSimulation::bReadIniFile(void)
 {
-   m_strCMEIni = m_strCMEDir;
+   // Check if user has supplied home directory
+   if (m_strCMEIni.empty())
+      // if not use the cme executable directory to find cme.ini
+      m_strCMEIni = m_strCMEDir;
+   else
+   {
+      // if user has supplied home directory replace cme run directory with user supplied dir
+      m_strCMEDir = m_strCMEIni;
+   }
    m_strCMEIni.append(CME_INI);
+
 
    // The .ini file is assumed to be in the CoastalME executable's directory
    string strFilePathName(m_strCMEIni);

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -595,14 +595,14 @@ int CSimulation::nDoSimulation(int nArg, char const* pcArgv[])
    // Start the clock ticking
    StartClock();
 
-   // Find out the folder in which the CoastalME executable sits, in order to open the .ini file (they are assumed to be in the same folder)
-   if (! bFindExeDir(pcArgv[0]))
-      return (RTN_ERR_CMEDIR);
-
    // Deal with command-line parameters
    int nRet = nHandleCommandLineParams (nArg, pcArgv);
    if (nRet != RTN_OK)
       return (nRet);
+
+   // Find out the folder in which the CoastalME executable sits, in order to open the .ini file (they are assumed to be in the same folder)
+   if (! bFindExeDir(pcArgv[0]))
+      return (RTN_ERR_CMEDIR);
 
    // OK, we are off, tell the user about the licence and the start time
    AnnounceLicence();

--- a/src/simulation.h
+++ b/src/simulation.h
@@ -1509,7 +1509,8 @@ private:
 
 private:
    // Input and output routines
-   static int nHandleCommandLineParams(int, char const* []);
+   int nHandleCommandLineParams(int, char const* []);
+   void setString(const std::string& str);
    bool bReadIniFile(void);
    bool bReadRunDataFile(void);
    bool bOpenLogFile(void);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -92,7 +92,7 @@ int CSimulation::nHandleCommandLineParams(int nArg, char const* pcArgv[])
 #endif
 
       // change to lower case
-      strArg = strToLower(&strArg);
+      // strArg = strToLower(&strArg);
 
       if (strArg.find("--gdal") != string::npos)
       {
@@ -113,32 +113,54 @@ int CSimulation::nHandleCommandLineParams(int nArg, char const* pcArgv[])
          return (RTN_HELP_ONLY);
       }
 
-      else if (strArg.find("--about") != string::npos)
-      {
-         // User wants information about CoastalME
-         cout << ABOUT << endl;
-         cout << THANKS << endl;
-
-         return (RTN_HELP_ONLY);
-      }
-
-      // TODO 049 Handle other command line parameters e.g. path to .ini file, path to datafile
 
       else
       {
-         // Display usage information
-         cout << USAGE << endl;
-         cout << USAGE1 << endl;
-         cout << USAGE2 << endl;
-         cout << USAGE3 << endl;
-         cout << USAGE4 << endl;
-         cout << USAGE5 << endl;
+         if (strArg.find("--about") != string::npos)
+         {
+            // User wants information about CoastalME
+            cout << ABOUT << endl;
+            cout << THANKS << endl;
 
-         return (RTN_HELP_ONLY);
+            return (RTN_HELP_ONLY);
+         }
+         else
+         {
+            if (strArg.find("--home") != string::npos)
+            {
+               // Read in user defined runtime directory
+               string strTmp;
+               size_t pos = strArg.find('=');  // Find the position of '='
+               if (pos != std::string::npos) {  // Check if '=' is found
+                  m_strCMEIni = strArg.substr(pos + 1);  // Get the substring after '=' and assign it to the global variable
+               } else {
+                  std::cout << "No '=' found in the input string!" << std::endl;
+               }
+               return (RTN_OK);
+            }
+            // TODO 049 Handle other command line parameters e.g. path to .ini file, path to datafile
+            else
+            {
+               // Display usage information
+               cout << USAGE << endl;
+               cout << USAGE1 << endl;
+               cout << USAGE2 << endl;
+               cout << USAGE3 << endl;
+               cout << USAGE4 << endl;
+               cout << USAGE5 << endl;
+
+               return (RTN_HELP_ONLY);
+            }
+         }
       }
+
    }
 
    return RTN_OK;
+}
+
+void CSimulation::setString(const std::string& str) {
+    m_strCMEIni = str;
 }
 
 //===============================================================================================================================
@@ -207,7 +229,6 @@ bool CSimulation::bFindExeDir(char const* pcArg)
 
    return true;
 }
-
 //===============================================================================================================================
 //! Tells the user about the licence
 //===============================================================================================================================


### PR DESCRIPTION
Resolved issue, CME can now take the --home command line argument to direct it to the folder where the cme.ini file is located.
Changes made on apple silicone system, but also tested build and run on WSL2 (Ubuntu) system.

Details of exact changes outlined in commit log.