### PR TITLE
Adjusted runtime prompt

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1765,18 +1765,21 @@ void CSimulation::AnnounceProgress(void)
       // Stdout is connected to a tty, so not running as a background job
       static double sdElapsed = 0;
       static double sdToGo = 0;
+      static double sdExpectedRuntime = 0;
       time_t const tNow = time(nullptr);
 
       // Calculate time elapsed and remaining
       sdElapsed = difftime(tNow, m_tSysStartTime);
-      sdToGo = (sdElapsed * m_dSimDuration / m_dSimElapsed) - sdElapsed;
+      sdExpectedRuntime = (sdElapsed * m_dSimDuration / m_dSimElapsed);
+      sdToGo = sdExpectedRuntime  - sdElapsed;
 
       // Tell the user about progress (note need to make several separate calls to cout here, or MS VC++ compiler appears to get confused)
       cout << SIMULATING << strDispSimTime(m_dSimElapsed);
       cout << fixed << setprecision(3) << setw(9) << 100 * m_dSimElapsed / m_dSimDuration;
-      cout << "%   (elapsed " << strDispTime(sdElapsed, false, false) << " remaining ";
+      cout << "%   (elapsed " << strDispTime(sdElapsed, false, false) ;
 
-      cout << strDispTime(sdToGo, false, false) << ")  ";
+      cout << " remaining " << strDispTime(sdToGo, false, false);
+      cout << " total expected " << strDispTime(sdExpectedRuntime, false, false) << ")  ";
 
       // Add a 'marker' for GIS saves etc.
       if (m_bSaveGISThisIter)


### PR DESCRIPTION
This pull request enhances the progress reporting in the simulation by providing more detailed runtime information to the user. The main improvement is the addition of the total expected runtime in the progress output, making it easier to estimate when the simulation will complete.

This is primarily intended to aid with profiling and optimisations 

Progress reporting improvements:

* Added a new variable, `sdExpectedRuntime`, to track the total expected runtime of the simulation and included it in the progress message output. The output now shows elapsed time, remaining time, and total expected runtime for better user feedback.